### PR TITLE
only install production deps for new templates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -118,7 +118,7 @@ class Spike extends EventEmitter {
     promise
       .tap(() => { emit('info', 'initializing template') })
       .then(sprout.init.bind(sprout, opts.template, opts.root, sproutOptions))
-      .tap(() => { emit('info', 'installing dependencies') })
+      .tap(() => { emit('info', 'installing production dependencies') })
       .then(npmInstall.bind(null, opts))
       .then(() => { return new Spike({ root: opts.root }) })
       .done(
@@ -142,7 +142,7 @@ class Spike extends EventEmitter {
  * @return {Promise.<String>} promise for the command output
  */
 function npmInstall (opts) {
-  return node.call(exec, 'npm install', { cwd: opts.root })
+  return node.call(exec, 'npm install --production', { cwd: opts.root })
 }
 
 /**


### PR DESCRIPTION
This speeds up new project initialization by about 60%