### PR TITLE
Refactor plugin utils

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,7 @@ const BrowserSyncPlugin = require('browser-sync-webpack-plugin')
 const {accessSync} = require('fs')
 const hygienist = require('hygienist-middleware')
 const merge = require('lodash.merge')
-const {isFileIgnored} = require('./plugins/plugin_utils')
+const SpikeUtils = require('./plugins/plugin_utils')
 
 /**
  * @module Config
@@ -123,9 +123,10 @@ module.exports = class Config {
     res.server.files = [{
       match: allWatchedFiles,
       fn: (event, file) => {
+        const util = new SpikeUtils(this)
         const f = path.join(this.context, file.replace(p, ''))
         const files = this.spike.files.all
-        if (files.indexOf(f) < 0 && !isFileIgnored(this.spike.ignore, f) && event !== 'addDir') {
+        if (files.indexOf(f) < 0 && !util.isFileIgnored(f) && event !== 'addDir') {
           this.project.watcher.watch([], [], [f])
         }
       }
@@ -216,13 +217,15 @@ module.exports = class Config {
 
     this.babel = opts.babel
 
+    const util = new SpikeUtils(this)
+
     // TODO: revisit this before a stable launch
     this.plugins = [new FsPlugin(opts)]
       .concat(opts.plugins)
       .concat([
-        new JadePlugin(opts),
-        new CSSPlugin(opts),
-        new StaticPlugin(opts),
+        new JadePlugin(util),
+        new CSSPlugin(util),
+        new StaticPlugin(util),
         new BrowserSyncPlugin(opts.server, { callback: (_, bs) => {
           if (bs.utils.devIp.length) {
             this.project.emit('info', `External IP: http://${bs.utils.devIp[0]}:${this.spike.server.port}`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,6 @@ function compileCallback (id, err, stats) {
   if (err) {
     return this.emit('error', new Errors.Error({ id: id, message: err }))
   }
-
   // Webpack "soft errors" are classified as warnings in spike. An error is
   // an error. If it doesn't break the build, it's a warning.
   const jsonStats = stats.toJson()

--- a/lib/plugins/css_plugin.js
+++ b/lib/plugins/css_plugin.js
@@ -1,9 +1,8 @@
-const _eval = require('require-from-string')
-const util = require('./plugin_utils')
-
 /**
  * @module CSSPlugin
  */
+
+const _eval = require('require-from-string')
 
 /**
  * @class CSSWebpackPlugin
@@ -18,8 +17,8 @@ module.exports = class CSSWebpackPlugin {
    * @param {String} opts.root - project root
    * @param {Array} opts.dumpDirs - directories to dump to public
    */
-  constructor (opts) {
-    this.opts = opts
+  constructor (util) {
+    this.util = util
   }
 
   apply (compiler) {
@@ -28,7 +27,7 @@ module.exports = class CSSWebpackPlugin {
     // inject css files into webpack's pipeline
     compiler.plugin('make', (compilation, done) => {
       cssFiles = compiler.options.spike.files.css
-      util.addFilesAsWebpackEntries(cssFiles, this.opts, compilation)
+      this.util.addFilesAsWebpackEntries(compilation, cssFiles)
         .then((res) => done())
     })
 
@@ -48,7 +47,7 @@ module.exports = class CSSWebpackPlugin {
         const srcFn = dep._source._value
         let src = _eval(srcFn, f) // eslint-disable-line
         src = src[0][1] // this part is questionable, but it is what it is
-        const outputPath = util.getOutputPath(f, this.opts)
+        const outputPath = this.util.getOutputPath(f)
         const newPath = outputPath.replace(/\.[^/.]+$/, '.css')
         compilation.assets[newPath] = {
           source: () => { return src },
@@ -63,7 +62,8 @@ module.exports = class CSSWebpackPlugin {
     // is present
     compiler.plugin('compilation', (compilation) => {
       compilation.plugin('optimize-chunk-assets', (chunks, done) => {
-        util.removeAssets(compilation, cssFiles, this.opts, done)
+        this.util.removeAssets(compilation, cssFiles)
+        done()
       })
     })
   }

--- a/lib/plugins/css_plugin.js
+++ b/lib/plugins/css_plugin.js
@@ -28,7 +28,7 @@ module.exports = class CSSWebpackPlugin {
     compiler.plugin('make', (compilation, done) => {
       cssFiles = compiler.options.spike.files.css
       this.util.addFilesAsWebpackEntries(compilation, cssFiles)
-        .then((res) => done())
+        .done(() => done())
     })
 
     // grab the sources and dependencies and export them into the right files

--- a/lib/plugins/fs_plugin.js
+++ b/lib/plugins/fs_plugin.js
@@ -1,8 +1,10 @@
-const getFilesFromGlob = require('./plugin_utils').getFilesFromGlob
-
 /**
  * @module FSPlugin
  */
+
+const path = require('path')
+const glob = require('glob')
+const micromatch = require('micromatch')
 
 /**
  * @class FsWebpackPlugin
@@ -45,4 +47,43 @@ function pathToRegex (paths) {
   return new RegExp(paths.map((p, i) => {
     return p.replace(/\//g, '\\/')
   }).join('|'))
+}
+
+/**
+ * Given the config options, pulls all files from the fs that match any of the
+ * provided matchers.
+ * @param {Object} opts - spike config object
+ * @param {String} opts.root - project root
+ * @param {String} opts.dumpDirs - directories to dump into output folder
+ * @param {Array} opts.ignore - array of ignore patterns
+ * @param {Object} opts.matchers - matchers from spike config
+ * @param {Array} opts.module.loaders - webpack loaders from spike config
+ * @return {Array} all matching file paths, absolute
+ */
+function getFilesFromGlob (opts) {
+  let files = {}
+  const matcher = path.join(opts.root, '**/**')
+  files.all = glob.sync(matcher, { ignore: opts.ignore, dot: true, nodir: true })
+
+  // Grab any file match tests from user-provided loaders
+  const customLoaderTests = opts.module.loaders.reduce((m, l) => {
+    if (!l._core) m.push(l.test)
+    return m
+  }, [])
+
+  // push all files matched by custom loaders into a `custom` category
+  files.custom = []
+  for (const loaderTest of customLoaderTests) {
+    files.all.forEach((f) => {
+      if (f.match(loaderTest)) files.custom.push(f)
+    })
+  }
+
+  // Core matchers do not match files that are already covered by custom loaders
+  const allWithoutCustom = files.all.filter((f) => files.custom.indexOf(f) < 0)
+  for (const key in opts.matchers) {
+    files[key] = micromatch(allWithoutCustom, opts.matchers[key], { dot: true })
+  }
+
+  return files
 }

--- a/lib/plugins/jade_plugin.js
+++ b/lib/plugins/jade_plugin.js
@@ -28,7 +28,7 @@ module.exports = class JadeWebpackPlugin {
     compiler.plugin('make', (compilation, done) => {
       jadeFiles = compiler.options.spike.files.jade
       this.util.addFilesAsWebpackEntries(compilation, jadeFiles)
-        .then((res) => done())
+        .done(() => done())
     })
 
     // grab the sources and dependencies and export them into the right files

--- a/lib/plugins/jade_plugin.js
+++ b/lib/plugins/jade_plugin.js
@@ -1,9 +1,8 @@
-const util = require('./plugin_utils')
-const cheerio = require('cheerio')
-
 /**
  * @module JadePlugin
  */
+
+const cheerio = require('cheerio')
 
 /**
  * @class JadePlugin
@@ -18,8 +17,8 @@ module.exports = class JadeWebpackPlugin {
    * @param {String} opts.root - project root
    * @param {Array} opts.dumpDirs - directories to dump to public
    */
-  constructor (opts) {
-    this.opts = opts
+  constructor (util) {
+    this.util = util
   }
 
   apply (compiler) {
@@ -28,7 +27,7 @@ module.exports = class JadeWebpackPlugin {
     // inject jade files into webpack's pipeline
     compiler.plugin('make', (compilation, done) => {
       jadeFiles = compiler.options.spike.files.jade
-      util.addFilesAsWebpackEntries(jadeFiles, this.opts, compilation)
+      this.util.addFilesAsWebpackEntries(compilation, jadeFiles)
         .then((res) => done())
     })
 
@@ -65,11 +64,11 @@ module.exports = class JadeWebpackPlugin {
 
         // add HTML asset references as dependencies in webpack
         srcs.forEach((src) => {
-          const p = util.resolveRelativeSourcePath(src, this.opts)
+          const p = this.util.resolveRelativeSourcePath(src)
           dep.fileDependencies.push(p)
         })
 
-        const outputPath = util.getOutputPath(f, this.opts).replace(/\.jade$/, '.html')
+        const outputPath = this.util.getOutputPath(f).replace(/\.jade$/, '.html')
         compilation.assets[outputPath] = {
           source: () => { return src },
           size: () => { return src.length }
@@ -83,7 +82,8 @@ module.exports = class JadeWebpackPlugin {
     // is present
     compiler.plugin('compilation', (compilation) => {
       compilation.plugin('optimize-chunk-assets', (chunks, done) => {
-        util.removeAssets(compilation, jadeFiles, this.opts, done)
+        this.util.removeAssets(compilation, jadeFiles)
+        done()
       })
     })
   }

--- a/lib/plugins/plugin_utils.js
+++ b/lib/plugins/plugin_utils.js
@@ -1,5 +1,5 @@
 /**
- * @module PluginUtils
+ * @module SpikeUtils
  */
 
 const glob = require('glob')
@@ -10,148 +10,94 @@ const node = require('when/node')
 const SingleEntryDependency = require('webpack/lib/dependencies/SingleEntryDependency')
 const MultiEntryDependency = require('webpack/lib/dependencies/MultiEntryDependency')
 
-/**
- * Given the config options, pulls all files from the fs that match any of the
- * provided matchers.
- * @param {Object} opts - spike config object
- * @param {String} opts.root - project root
- * @param {String} opts.dumpDirs - directories to dump into output folder
- * @param {Array} opts.ignore - array of ignore patterns
- * @param {Object} opts.matchers - matchers from spike config
- * @param {Array} opts.module.loaders - webpack loaders from spike config
- * @return {Array} all matching file paths, absolute
- */
-function getFilesFromGlob (opts) {
-  let files = {}
-  const matcher = path.join(opts.root, '**/**')
-  files.all = glob.sync(matcher, { ignore: opts.ignore, dot: true, nodir: true })
+module.exports = class SpikeUtils {
+  constructor (config) {
+    this.conf = config
+  }
 
-  // Grab any file match tests from user-provided loaders
-  const customLoaderTests = opts.module.loaders.reduce((m, l) => {
-    if (!l._core) m.push(l.test)
-    return m
-  }, [])
+  /**
+   * Adds a number of files to webpack's pipeline as entires, so that webpack
+   * processes them even if they are not required in the main js file.
+   * @param {Object} compilation - object from plugin
+   * @param {Array} files - array of absolute paths to files
+   * @return {Promise.<Array>} compilation.addEntry return value for each file
+   */
+  addFilesAsWebpackEntries (compilation, files) {
+    return W.all(files.map((f) => {
+      const name = this.getOutputPath(f)
+      const relativePath = f.replace(this.conf.context, '.')
+      const dep = new MultiEntryDependency([new SingleEntryDependency(relativePath)], name)
+      const addEntryFn = compilation.addEntry.bind(compilation)
 
-  // push all files matched by custom loaders into a `custom` category
-  files.custom = []
-  for (const loaderTest of customLoaderTests) {
-    files.all.forEach((f) => {
-      if (f.match(loaderTest)) files.custom.push(f)
+      return node.call(addEntryFn, this.conf.context, dep, name)
+    }))
+  }
+
+  /**
+   * Given a source file path, outputs the file's destination as spike
+   * will write it.
+   * @param {String} file - path to source file
+   * @return {String} output path
+   */
+  getOutputPath (file) {
+    let rel = file.replace(this.conf.context, '')
+
+    this.conf.spike.dumpDirs.forEach((d) => {
+      const re = new RegExp(`^${path.sep}${d}`)
+      if (rel.match(re)) { rel = rel.replace(`${path.sep}${d}`, '') }
     })
+
+    return rel.substring(1)
   }
 
-  // Core matchers do not match files that are already covered by custom loaders
-  const allWithoutCustom = files.all.filter((f) => files.custom.indexOf(f) < 0)
-  for (const key in opts.matchers) {
-    files[key] = micromatch(allWithoutCustom, opts.matchers[key], { dot: true })
+  /**
+   * Removes assets from the webpack compilation, so that static files are not
+   * written to the js file, since we already write them as static files.
+   * @param {Object} compilation - webpack compilation object from plugin
+   * @param {Array} _files - array of absolute paths to processed files
+   * @param {Function} done - callback
+   */
+  removeAssets (compilation, _files) {
+    // assets are set in compilation.assets as the output path, relative to
+    // the root, with '.js' at the end, so we transform to that format for
+    // comparison
+    let files = _files.map((f) => {
+      return this.getOutputPath(f).replace(`${this.conf.context}/`, '') + '.js'
+    })
+    // now we go through all the assets and remove the ones we have processed
+    // with spike so that they are not written to the js file
+    for (const a in compilation.assets) {
+      if (files.indexOf(a) > -1) { delete compilation.assets[a] }
+    }
   }
 
-  return files
-}
-exports.getFilesFromGlob = getFilesFromGlob
+  /**
+   * Takes a relative path like `img/foo.png` and resolves it to an absolute
+   * path. Function respects your dumpDirs and knows how to resolve it's
+   * absolute source path.
+   * @param {String} file - a relative path
+   * @return {String} absolute path to the file
+   */
+  resolveRelativeSourcePath (file) {
+    let rel = file.replace(this.conf.context, '')
 
-/**
- * Adds a number of files to webpack's pipeline as entires, so that webpack
- * processes them even if they are not required in the main js file.
- * @param {Array} files - array of absolute paths to files
- * @param {Object} opts - spike config object
- * @param {String} opts.root - project root
- * @param {String} opts.dumpDirs - directories to dump into output folder
- * @param {Object} compilation - object from plugin
- * @return {Promise.<Array>} compilation.addEntry return value for each file
- */
-function addFilesAsWebpackEntries (files, opts, compilation) {
-  return W.all(files.map((f) => {
-    const name = getOutputPath(f, opts)
-    const relativePath = f.replace(opts.root, '.')
-    const dep = new MultiEntryDependency([new SingleEntryDependency(relativePath)], name)
-    const addEntryFn = compilation.addEntry.bind(compilation)
+    // check to see if the file is from a dumpDir path
+    /* istanbul ignore next */
+    // https://github.com/bcoe/nyc/issues/259
+    glob.sync(`*(${this.conf.spike.dumpDirs.join('|')})/**`).forEach((d) => {
+      const test = new RegExp(rel)
+      if (d.match(test)) { rel = d }
+    })
 
-    return node.call(addEntryFn, opts.root, dep, name)
-  }))
-}
-exports.addFilesAsWebpackEntries = addFilesAsWebpackEntries
-
-/**
- * Given a source file path, outputs the file's destination as spike
- * will write it.
- * @param {String} file - path to source file
- * @param {Object} opts - spike config object
- * @param {String} opts.root - project root
- * @param {String} opts.dumpDirs - directories to dump into output folder
- * @return {String} output path
- */
-function getOutputPath (file, opts) {
-  let rel = file.replace(opts.root, '')
-
-  opts.dumpDirs.forEach((d) => {
-    const re = new RegExp(`^${path.sep}${d}`)
-    if (rel.match(re)) { rel = rel.replace(`${path.sep}${d}`, '') }
-  })
-
-  return rel.substring(1)
-}
-exports.getOutputPath = getOutputPath
-
-/**
- * Removes assets from the webpack compilation, so that static files are not
- * written to the js file, since we already write them as static files.
- * @param {Object} compilation - webpack compilation object from plugin
- * @param {Array} _files - array of absolute paths to processed files
- * @param {Object} opts - spike config object
- * @param {String} opts.root - project root
- * @param {String} opts.dumpDirs - directories to dump into output folder
- * @param {Function} done - callback
- */
-function removeAssets (compilation, _files, opts, done) {
-  // assets are set in compilation.assets as the output path, relative to
-  // the root, with '.js' at the end, so we transform to that format for
-  // comparison
-  let files = _files.map((f) => {
-    return getOutputPath(f, opts).replace(`${opts.root}/`, '') + '.js'
-  })
-  // now we go through all the assets and remove the ones we have processed
-  // with spike so that they are not written to the js file
-  for (const a in compilation.assets) {
-    if (files.indexOf(a) > -1) { delete compilation.assets[a] }
+    return path.join(this.conf.context, rel)
   }
-  done()
+
+  /**
+   * Boolean return whether a file matches any of the configured ignores.
+   * @param {String} file - absolute file path
+   * @return {Boolean} whether the file is ignored or not
+   */
+  isFileIgnored (file) {
+    return micromatch.any(file, this.conf.spike.ignore)
+  }
 }
-exports.removeAssets = removeAssets
-
-/**
- * Takes a relative path like `img/foo.png` and resolves it to an absolute
- * path. Function respects your dumpDirs and knows how to resolve it's
- * absolute source path.
- * @param {Object} compiler - the webpack compiler object
- * @param {String} file - a relative path
- * @param {Object} opts - spike config object
- * @param {String} opts.root - project root
- * @param {String} opts.dumpDirs - directories to dump into output folder
- * @return {String} absolute path to the file
- */
-function resolveRelativeSourcePath (file, opts) {
-  let rel = file.replace(opts.root, '')
-
-  // check to see if the file is from a dumpDir path
-  /* istanbul ignore next */
-  // https://github.com/bcoe/nyc/issues/259
-  glob.sync(`*(${opts.dumpDirs.join('|')})/**`).forEach((d) => {
-    const test = new RegExp(`${rel}`)
-    if (d.match(test)) { rel = d }
-  })
-
-  return path.join(opts.root, rel)
-}
-exports.resolveRelativeSourcePath = resolveRelativeSourcePath
-
-/**
- * Boolean return whether a file matches any of the configured ignores.
- * @param {Array} ignores - ignores option from spike config
- * @param {String} file - absolute file path
- * @return {Boolean} whether the file is ignored or not
- */
-function isFileIgnored (ignores, file) {
-  return micromatch.any(file, ignores)
-}
-exports.isFileIgnored = isFileIgnored

--- a/lib/plugins/plugin_utils.js
+++ b/lib/plugins/plugin_utils.js
@@ -10,6 +10,10 @@ const node = require('when/node')
 const SingleEntryDependency = require('webpack/lib/dependencies/SingleEntryDependency')
 const MultiEntryDependency = require('webpack/lib/dependencies/MultiEntryDependency')
 
+/**
+ * @class SpikeUtils
+ * @classdesc A small set of utility functions for spike plugins
+ */
 module.exports = class SpikeUtils {
   constructor (config) {
     this.conf = config

--- a/lib/plugins/static_plugin.js
+++ b/lib/plugins/static_plugin.js
@@ -1,5 +1,3 @@
-const util = require('./plugin_utils')
-
 /**
  * @module StaticPlugin
  */
@@ -17,8 +15,8 @@ module.exports = class StaticWebpackPlugin {
    * @param {String} opts.root - project root
    * @param {Array} opts.dumpDirs - directories to dump to public
    */
-  constructor (opts) {
-    this.opts = opts
+  constructor (util) {
+    this.util = util
   }
 
   apply (compiler) {
@@ -27,7 +25,7 @@ module.exports = class StaticWebpackPlugin {
     // inject static files into webpack's pipeline
     compiler.plugin('make', (compilation, done) => {
       staticFiles = compiler.options.spike.files.static
-      util.addFilesAsWebpackEntries(staticFiles, this.opts, compilation)
+      this.util.addFilesAsWebpackEntries(compilation, staticFiles)
         .then((res) => done())
     })
 
@@ -45,13 +43,13 @@ module.exports = class StaticWebpackPlugin {
         if (dep.error) { return done(dep.error) }
 
         // webpack stores this value using the relative path as a key
-        let relativePath = util.getOutputPath(f, this.opts)
-          .replace(this.opts.root, '')
+        let relativePath = this.util.getOutputPath(f)
+          .replace(this.util.conf.context, '')
 
         // now we pull the value from the dependency using the correct key
         const src = dep.assets[relativePath]._value
 
-        const outputPath = util.getOutputPath(f, this.opts)
+        const outputPath = this.util.getOutputPath(f)
         compilation.assets[outputPath] = {
           source: () => { return src },
           size: () => { return src.length }
@@ -64,7 +62,8 @@ module.exports = class StaticWebpackPlugin {
     // remove static assets from webpack pipeline
     compiler.plugin('compilation', (compilation) => {
       compilation.plugin('optimize-chunk-assets', (chunks, done) => {
-        util.removeAssets(compilation, staticFiles, this.opts, done)
+        this.util.removeAssets(compilation, staticFiles)
+        done()
       })
     })
   }

--- a/lib/plugins/static_plugin.js
+++ b/lib/plugins/static_plugin.js
@@ -26,7 +26,7 @@ module.exports = class StaticWebpackPlugin {
     compiler.plugin('make', (compilation, done) => {
       staticFiles = compiler.options.spike.files.static
       this.util.addFilesAsWebpackEntries(compilation, staticFiles)
-        .then((res) => done())
+        .done(() => done())
     })
 
     // grab the sources and dependencies and export them into the right files

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/static-dev/spike/issues",
   "dependencies": {
-    "babel-core": "^6.8.0",
+    "babel-core": "^6.9.0",
     "babel-loader": "^6.2.0",
     "browser-sync": "^2.11.1",
     "browser-sync-webpack-plugin": "^1.0.1",
@@ -31,7 +31,7 @@
     "require-from-string": "^1.2.0",
     "rimraf": "^2.5.2",
     "sprout": "^1.2.0",
-    "webpack": "^1.12.10",
+    "webpack": "^1.13.0",
     "when": "^3.7.7"
   },
   "devDependencies": {
@@ -42,7 +42,7 @@
     "md5-file": "^2.0.4",
     "nyc": "^6.4.4",
     "snazzy": "^4.0.0",
-    "standard": "^7.0.1",
+    "standard": "^7.1.0",
     "sugarss": "^0.1.2"
   },
   "engines": {

--- a/test/compile.js
+++ b/test/compile.js
@@ -13,7 +13,6 @@ test.cb('emits compile warnings correctly', (t) => {
   const project = new Spike({ root: path.join(fixturesPath, 'css') })
 
   project.on('error', t.end)
-  // project.on('compile', console.log)
   project.on('warning', (msg) => {
     t.truthy(msg.toString().match(/Cannot resolve 'file' or 'directory' \.\/assets\/js\/index\.js/))
     t.end()

--- a/test/compile.js
+++ b/test/compile.js
@@ -13,6 +13,7 @@ test.cb('emits compile warnings correctly', (t) => {
   const project = new Spike({ root: path.join(fixturesPath, 'css') })
 
   project.on('error', t.end)
+  // project.on('compile', console.log)
   project.on('warning', (msg) => {
     t.truthy(msg.toString().match(/Cannot resolve 'file' or 'directory' \.\/assets\/js\/index\.js/))
     t.end()


### PR DESCRIPTION
So this refactor gets us to a place where, if we could get the external `spike-utils` module working, it would work, and we could swap it out in one place. However, it doesn't work due to a very nasty issue deep in webpack's core. Either way, we keep the same functionality with this PR, and get the structure we need to immediately switch in the utils once they are ready, so 🚒 