### PR TITLE
Fix merging of nested options objects from API

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -26,7 +26,8 @@ module.exports = class Config {
       throw new Error('[spike constructor] option "root" is required')
     }
     // merges API options into app.js options
-    let allOpts = Object.assign(this.parseAppJs(opts), opts)
+    let appJsOpts = this.parseAppJs(opts)
+    let allOpts = mergeNestedObjects(appJsOpts, opts)
     this.transformSpikeOptionsToWebpack(this.validateOpts(allOpts))
     this.project = project
   }
@@ -284,3 +285,31 @@ function filterKeys (obj, keys) {
   for (const k in obj) { if (keys.indexOf(k) > 0) res[k] = obj[k] }
   return res
 }
+
+function mergeProperties(propertyKey, firstObject, secondObject) {
+    var propertyValue = firstObject[propertyKey];
+
+    if (secondObject === undefined || secondObject[propertyKey] === undefined) {
+        return firstObject[propertyKey];
+    } else if (typeof(propertyValue) === "object") {
+        return mergeNestedObjects(firstObject[propertyKey], secondObject[propertyKey]);
+    } 
+
+    return secondObject[propertyKey];
+}
+
+function mergeNestedObjects(firstObject, secondObject) {
+    var finalObject = {};
+
+    // Merge first object and its properties.
+    for (var propertyKey in firstObject) {
+        finalObject[propertyKey] = mergeProperties(propertyKey, firstObject, secondObject);
+    }
+
+    // Merge second object and its properties.
+    for (var propertyKey in secondObject) {
+        finalObject[propertyKey] = mergeProperties(propertyKey, secondObject, firstObject);
+    }
+
+    return finalObject;
+} 

--- a/lib/config.js
+++ b/lib/config.js
@@ -27,7 +27,7 @@ module.exports = class Config {
     }
     // merges API options into app.js options
     let appJsOpts = this.parseAppJs(opts)
-    let allOpts = mergeNestedObjects(appJsOpts, opts)
+    let allOpts = merge(appJsOpts, opts)
     this.transformSpikeOptionsToWebpack(this.validateOpts(allOpts))
     this.project = project
   }
@@ -284,32 +284,4 @@ function filterKeys (obj, keys) {
   const res = {}
   for (const k in obj) { if (keys.indexOf(k) > 0) res[k] = obj[k] }
   return res
-}
-
-function mergeProperties (propertyKey, firstObject, secondObject) {
-  var propertyValue = firstObject[propertyKey]
-
-  if (secondObject === undefined || secondObject[propertyKey] === undefined) {
-    return firstObject[propertyKey]
-  } else if (typeof propertyValue === 'object') {
-    return mergeNestedObjects(firstObject[propertyKey], secondObject[propertyKey])
-  }
-
-  return secondObject[propertyKey]
-}
-
-function mergeNestedObjects (firstObject, secondObject) {
-  var finalObject = {}
-
-  // Merge first object and its properties.
-  for (var propertyKey in firstObject) {
-    finalObject[propertyKey] = mergeProperties(propertyKey, firstObject, secondObject)
-  }
-
-  // Merge second object and its properties.
-  for (var propertyKey2 in secondObject) {
-    finalObject[propertyKey2] = mergeProperties(propertyKey2, secondObject, firstObject)
-  }
-
-  return finalObject
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,8 +26,7 @@ module.exports = class Config {
       throw new Error('[spike constructor] option "root" is required')
     }
     // merges API options into app.js options
-    let appJsOpts = this.parseAppJs(opts)
-    let allOpts = merge(appJsOpts, opts)
+    let allOpts = merge(this.parseAppJs(opts), opts)
     this.transformSpikeOptionsToWebpack(this.validateOpts(allOpts))
     this.project = project
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -286,30 +286,30 @@ function filterKeys (obj, keys) {
   return res
 }
 
-function mergeProperties(propertyKey, firstObject, secondObject) {
-    var propertyValue = firstObject[propertyKey];
+function mergeProperties (propertyKey, firstObject, secondObject) {
+  var propertyValue = firstObject[propertyKey]
 
-    if (secondObject === undefined || secondObject[propertyKey] === undefined) {
-        return firstObject[propertyKey];
-    } else if (typeof(propertyValue) === "object") {
-        return mergeNestedObjects(firstObject[propertyKey], secondObject[propertyKey]);
-    } 
+  if (secondObject === undefined || secondObject[propertyKey] === undefined) {
+    return firstObject[propertyKey]
+  } else if (typeof propertyValue === 'object') {
+    return mergeNestedObjects(firstObject[propertyKey], secondObject[propertyKey])
+  }
 
-    return secondObject[propertyKey];
+  return secondObject[propertyKey]
 }
 
-function mergeNestedObjects(firstObject, secondObject) {
-    var finalObject = {};
+function mergeNestedObjects (firstObject, secondObject) {
+  var finalObject = {}
 
-    // Merge first object and its properties.
-    for (var propertyKey in firstObject) {
-        finalObject[propertyKey] = mergeProperties(propertyKey, firstObject, secondObject);
-    }
+  // Merge first object and its properties.
+  for (var propertyKey in firstObject) {
+    finalObject[propertyKey] = mergeProperties(propertyKey, firstObject, secondObject)
+  }
 
-    // Merge second object and its properties.
-    for (var propertyKey in secondObject) {
-        finalObject[propertyKey] = mergeProperties(propertyKey, secondObject, firstObject);
-    }
+  // Merge second object and its properties.
+  for (var propertyKey2 in secondObject) {
+    finalObject[propertyKey2] = mergeProperties(propertyKey2, secondObject, firstObject)
+  }
 
-    return finalObject;
-} 
+  return finalObject
+}

--- a/test/app_config.js
+++ b/test/app_config.js
@@ -15,7 +15,7 @@ test('API config overrides app.js config', (t) => {
 
 test('API config merges properly with app.js config', (t) => {
   return compileFixture(t, 'app_config', { testing: { bar: 'double override' } }).then(({res}) => {
-    t.truthy(res.stats.compilation.options.testing.foo === 'override')
+    t.truthy(res.stats.compilation.options.testing.baz === 'override')
     t.truthy(res.stats.compilation.options.testing.bar === 'double override')
   })
 })

--- a/test/app_config.js
+++ b/test/app_config.js
@@ -13,6 +13,13 @@ test('API config overrides app.js config', (t) => {
   })
 })
 
+test('API config merges properly with app.js config', (t) => {
+  return compileFixture(t, 'app_config', { testing: { bar: 'double override' } }).then(({res}) => {
+    t.truthy(res.stats.compilation.options.testing.foo === 'override')
+    t.truthy(res.stats.compilation.options.testing.bar === 'double override')
+  })
+})
+
 test('throws error for invalid app.js syntax', (t) => {
   return t.throws(() => compileFixture(t, 'app_config_error'), /Error: wow/)
 })

--- a/test/fixtures/app_config/app.js
+++ b/test/fixtures/app_config/app.js
@@ -1,5 +1,7 @@
 module.exports = {
   testing: {
-    foo: 'override'
+    foo: 'override',
+    bar: 'override',
+    baz: 'override'
   }
 }


### PR DESCRIPTION
Relates to static-dev/spike#38

Referenced PR exposed issue that nested options objects being passed from the API are not merged properly with options from `App.js` – Because `Object.assign` copies the full reference over if the value of a key:value pair is an object. This was leading to server options set in `App.js` being ignored. 

This PR fixes this issue by changing the way options are merged to use a method suitable for nested objects. 

There is a new test to check that the merge is operating properly.