### PR TITLE
Add `afterSpikePlugins` option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -229,8 +229,8 @@ module.exports = class Config {
     const util = new SpikeUtils(this)
 
     this.plugins = [
-      ...opts.plugins,
       new SpikePlugin(util),
+      ...opts.plugins,
       new BrowserSyncPlugin(opts.server, { callback: (_, bs) => {
         if (bs.utils.devIp.length) {
           this.project.emit('info', `External IP: http://${bs.utils.devIp[0]}:${this.spike.server.port}`)

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,6 +59,7 @@ module.exports = class Config {
       modulesDirectories: Joi.array().default(['node_modules', 'bower_components']),
       outputDir: Joi.string().default('public'),
       plugins: Joi.array().default([]),
+      afterSpikePlugins: Joi.array().default([]),
       module: Joi.object().default().keys({
         loaders: Joi.array().default([])
       }),
@@ -229,8 +230,9 @@ module.exports = class Config {
     const util = new SpikeUtils(this)
 
     this.plugins = [
-      new SpikePlugin(util),
       ...opts.plugins,
+      new SpikePlugin(util),
+      ...opts.afterSpikePlugins,
       new BrowserSyncPlugin(opts.server, { callback: (_, bs) => {
         if (bs.utils.devIp.length) {
           this.project.emit('info', `External IP: http://${bs.utils.devIp[0]}:${this.spike.server.port}`)

--- a/test/fixtures/plugins/after_plugin.js
+++ b/test/fixtures/plugins/after_plugin.js
@@ -1,0 +1,12 @@
+module.exports = class AfterSpikeWebpackPlugin {
+  constructor (opts) {
+    this.opts = opts
+  }
+
+  apply (compiler) {
+    compiler.plugin('emit', (compilation, done) => {
+      this.opts.emitter.emit('check', Object.keys(compilation.assets).includes('changed_output.html'))
+      done()
+    })
+  }
+}

--- a/test/fixtures/plugins/app.js
+++ b/test/fixtures/plugins/app.js
@@ -2,6 +2,6 @@ const TestPlugin = require('./plugin.js')
 
 module.exports = {
   test: 'foo',
-  ignore: ['app.js', 'plugin.js'],
+  ignore: ['app.js', 'plugin.js', 'after_plugin.js'],
   plugins: [new TestPlugin()]
 }

--- a/test/fixtures/plugins/plugin.js
+++ b/test/fixtures/plugins/plugin.js
@@ -1,4 +1,4 @@
-module.exports = class JadeWebpackPlugin {
+module.exports = class TestWebpackPlugin {
   constructor (opts) {
     this.opts = opts
   }

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,14 +1,20 @@
 const test = require('ava')
 const path = require('path')
+const EventEmitter = require('events')
+const AfterPlugin = require('./fixtures/plugins/after_plugin')
 const {compileFixture, fs} = require('./_helpers')
 
 test('compiles a project with a custom plugin, plugins can change output path', (t) => {
-  return compileFixture(t, 'plugins')
-    .then(({res, publicPath}) => {
-      const index = path.join(publicPath, 'index.html')
-      const outputChanged = path.join(publicPath, 'changed_output.html')
-      fs.statSync(index)
-      fs.statSync(outputChanged)
-      t.truthy(res.stats.compilation.options.test === 'bar')
-    })
+  t.plan(2)
+  const emitter = new EventEmitter()
+  emitter.on('check', (val) => { t.is(val, true) })
+  return compileFixture(t, 'plugins', {
+    afterSpikePlugins: [new AfterPlugin({ emitter })]
+  }).then(({res, publicPath}) => {
+    const index = path.join(publicPath, 'index.html')
+    const outputChanged = path.join(publicPath, 'changed_output.html')
+    fs.statSync(index)
+    fs.statSync(outputChanged)
+    t.truthy(res.stats.compilation.options.test === 'bar')
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,10 +2394,11 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-husky@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.12.0.tgz#3a44922fce8071803242c3c7522a6582c50525dc"
+husky@^0.13.0:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.1.tgz#11efc6fc10e0ec4e789776f6582be37d71ba4ccf"
   dependencies:
+    chalk "^1.1.3"
     find-parent-dir "^0.3.0"
     is-ci "^1.0.9"
     normalize-path "^1.0.0"


### PR DESCRIPTION
This lets user-added plugins access spike-generated assets. Specifically this makes the offline plugin work perfectly for generating service workers.