### PR TITLE
Browser sync proxy

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -68,7 +68,15 @@ module.exports = class Config {
         watchOptions: Joi.object().default().keys({
           ignored: Joi.array().default('node_modules')
         }),
-        server: Joi.object().default({}),
+        server: Joi.default({})
+          .when('proxy', { is: Joi.exist(),
+            then: Joi.required().only(false),
+            otherwise: Joi.object()
+          }),
+        proxy: Joi.alternatives().try(
+          Joi.object().keys({ target: Joi.string().required() }),
+          Joi.string()
+        ).optional(),
         port: Joi.number().default(1111),
         middleware: Joi.array().default([]),
         logLevel: Joi.string().default('silent'),

--- a/lib/config.js
+++ b/lib/config.js
@@ -91,7 +91,9 @@ module.exports = class Config {
     let res = validation.value
 
     // Joi can't handle defaulting this, so we do it manually
-    res.server.server.baseDir = res.outputDir.replace(res.root, '')
+    if (res.server.server) {
+      res.server.server.baseDir = res.outputDir.replace(res.root, '')
+    }
 
     // add cleanUrls middleware to browserSync if cleanUrls === true
     if (res.cleanUrls) {

--- a/test/config_errors.js
+++ b/test/config_errors.js
@@ -14,4 +14,8 @@ test('config errors', (t) => {
     'ValidationError: child "babel" fails because ["babel" must be an object]')
   t.throws(() => { new Spike({ root: 'foo', entry: ['foo', 'bar'] }) }, // eslint-disable-line
     'ValidationError: child "entry" fails because ["entry" must be an object]')
+  t.throws(() => { new Spike({ root: 'foo', server: {server: false} }) }, // eslint-disable-line
+    'ValidationError: child "server" fails because [child "server" fails because ["server" must be an object]]')
+  t.throws(() => { new Spike({ root: 'foo', server: {server: {}, proxy: 'http://localhost:1234/'} }) }, // eslint-disable-line
+    'ValidationError: child "server" fails because [child "server" fails because ["server" must be one of [false]]]')
 })


### PR DESCRIPTION
I added a `Config.server.proxy` option for browser-syn, to allow proxy to different server in the background (which then handles serving the spike built files). This option must be `string` or `object` with key `target`, and if is defined, `Config.server.server` must be set to `false`.

I added all of this to Joi schema and put the `Config.server.server.baseDir` setting behind check for existence of server.