### PR TITLE
fix: don't swallow require error

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const Joi = require('joi')
-const micromatch = require('micromatch')
+const {makeRe} = require('micromatch')
 const union = require('lodash.union')
 const merge = require('lodash.merge')
 const {accessSync} = require('fs')
@@ -214,7 +214,7 @@ module.exports = class Config {
       this.resolveLoader = merge(opts.resolveLoader, this.resolveLoader)
     }
 
-    const reIgnores = opts.ignore.map(mmToRe)
+    const reIgnores = opts.ignore.map(makeRe)
     const spikeLoaders = [
       {
         exclude: reIgnores,
@@ -289,15 +289,15 @@ module.exports = class Config {
 function loadFile (f) {
   try {
     accessSync(f)
+  } catch (err) {
+    throw err
+  }
+
+  try {
     return require(f)
   } catch (err) {
-    if (err.code !== 'ENOENT') { throw new Error(err) }
-    return {}
+    throw err
   }
-}
-
-function mmToRe (mm) {
-  return micromatch.makeRe(mm)
 }
 
 function removeKeys (obj, keys) {


### PR DESCRIPTION
- fixes error handling when files are unable to be required due to invalid javascript
- removes mmToRe wrapper