### PR TITLE
Check for package.json before trying to install dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,6 +151,9 @@ function uuid () {
  * @return {Promise.<String>} promise for the command output
  */
 function npmInstall (opts) {
+  const pkgPath = path.join(opts.root, 'package.json')
+  if (!fs.existsSync(pkgPath)) { return }
+
   return node.call(exec, 'npm install --production', { cwd: opts.root })
 }
 


### PR DESCRIPTION
The tests kept failing when running multiple times, because this Spike.new tries to install NPM dependencies without a check for existence of a package.json file, so if the new Spike project was in a child directory of another node project, it would call the 'npm install --production' on the parent instead — which is a problem, especially for repositories using yarn.

This add a synchronous explicit check for 'package.json' before trying to install.